### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Transmutation
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/transmutation`. To experiment with that code, run `bin/console` for an interactive prompt.
+Transmutation is a Ruby gem that provides a simple way to serialize Ruby objects into JSON.
 
-TODO: Delete this and the text above, and describe your gem
+It takes inspiration from the [Active Model Serializers](https://github.com/rails-api/active_model_serializers) gem, but strips away adapters.
+
+It aims to be a performant and elegant solution for serializing Ruby objects into JSON, with a touch of opinionated "magic" :sparkles:.
 
 ## Installation
 
@@ -16,7 +18,71 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Usage
 
-TODO: Write usage instructions here
+### Basic Usage
+
+- Define a serializer class that inherits from `Transmutation::Serializer` and define the attributes to be serialized.
+
+  ```ruby
+  class UserSerializer < Transmutation::Serializer
+    attributes :id, :name, :email
+  end
+  ```
+
+- Serialize an object using the serializer class.
+
+  ```ruby
+  class User
+    attr_reader :id, :name, :email
+
+    def initialize(id:, name:, email:)
+      @id = id
+      @name = name
+      @email = email
+    end
+  end
+
+  user = User.new(id: 1, name: "John Doe", email: "john@example.com")
+
+  UserSerializer.new(user).to_json # => "{\"id\":1,\"name\":\"John Doe\",\"email\":\"john@example.com\"}"
+  ```
+
+  As long as your object responds to the attributes defined in the serializer, it can be serialized.
+
+  - Struct
+
+    ```ruby
+    User = Struct.new(:id, :name, :email)
+    ```
+
+  - Class
+
+    ```ruby
+    class User
+      attr_reader :id, :name, :email
+
+      def initialize(id:, name:, email:)
+        @id = id
+        @name = name
+        @email = email
+      end
+    end
+    ```
+
+  - ActiveRecord
+
+    ```ruby
+    # == Schema Information
+    #
+    # Table name: users
+    #
+    #  id    :bigint
+    #  name  :string
+    #  email :string
+    class User < ApplicationRecord
+    end
+    ```
+
+### Using the `Transmutation::Serialization` module
 
 ## Development
 
@@ -26,7 +92,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/transmutation. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/transmutation/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/spellbook-technology/transmutation. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/spellbook-technology/transmutation/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -34,4 +100,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Transmutation project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/transmutation/blob/main/CODE_OF_CONDUCT.md).
+Everyone interacting in the Transmutation project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/spellbook-technology/transmutation/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Add inspiration, description, and usage instructions to [README.md](https://github.com/spellbook-technology/transmutation/blob/6e1f2b8c357daa97472bd8628a2618f0ad53156f/README.md).

The `Transmutation::Serialization` module documentation is empty, as we'll update the code soon.