### PR TITLE
Add serialize method to Serialization

### DIFF
--- a/lib/transmutation/collection_serializer.rb
+++ b/lib/transmutation/collection_serializer.rb
@@ -8,7 +8,7 @@ module Transmutation
 
     def as_json(options = {})
       objects.map do |object|
-        Transmutation::Serialization.serialize(object, options)
+        Transmutation::Serialization.serialize(object).as_json(options)
       end
     end
 

--- a/lib/transmutation/serialization.rb
+++ b/lib/transmutation/serialization.rb
@@ -6,8 +6,8 @@ module Transmutation
       Object.const_get("::#{object.class}Serializer")
     end
 
-    def self.serialize(object, options = {})
-      lookup_serializer(object).new(object).as_json(options)
+    def self.serialize(object)
+      lookup_serializer(object).new(object)
     end
 
     def render(**args)

--- a/spec/transmutation/serialization_spec.rb
+++ b/spec/transmutation/serialization_spec.rb
@@ -83,9 +83,8 @@ RSpec.describe Transmutation::Serialization do
   end
 
   describe "#serialize" do
-    it "returns the serialized object as JSON" do
-      json = described_class.serialize(example_object)
-      expect(json).to eq({ "first_name" => "John" })
+    it "returns the wrapped object in corresponding serializer" do
+      expect(described_class.serialize(example_object).class).to eq(ExampleObjectSerializer)
     end
   end
 end


### PR DESCRIPTION
- Add a `serialize` helper method to shorten the manual `lookup_serialize` process
- Update the `as_json` method in CollectionSerializer to use a new `serialize` method
- Add tests of the `serialize` method to Serialization