### PR TITLE
Add ability to pass a block to Serializer.association

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ gem "simplecov-lcov"
 gem "undercover"
 
 gem "pry"
+
+gem "gem-release", require: false

--- a/lib/transmutation/version.rb
+++ b/lib/transmutation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Transmutation
-  VERSION = "0.4.5"
+  VERSION = "0.5.0"
 end

--- a/spec/system/dummy/models/post.rb
+++ b/spec/system/dummy/models/post.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class Post
-  attr_accessor :id, :title, :body, :user_id
+  attr_accessor :id, :title, :body, :user_id, :published_at
 
-  def initialize(id:, title:, body:, user_id: nil)
+  def initialize(id:, title:, body:, user_id: nil, published_at: nil)
     self.id = id
     self.title = title
     self.body = body
     self.user_id = user_id
+    self.published_at = published_at
   end
 
   def user
@@ -20,9 +21,9 @@ class Post
 
   def self.all
     [
-      Post.new(id: 1, title: "First post", body: "First!", user_id: 1),
-      Post.new(id: 2, title: "How does this work?", body: "body", user_id: 2),
-      Post.new(id: 3, title: "Second post!?", body: "Nope...", user_id: 1)
+      Post.new(id: 1, title: "First post", body: "First!", user_id: 1, published_at: Time.now),
+      Post.new(id: 2, title: "How does this work?", body: "body", user_id: 2, published_at: Time.now),
+      Post.new(id: 3, title: "Second post!?", body: "Nope...", user_id: 1, published_at: nil)
     ]
   end
 

--- a/spec/system/dummy/serializers/api/v1/detailed/user_serializer.rb
+++ b/spec/system/dummy/serializers/api/v1/detailed/user_serializer.rb
@@ -7,6 +7,10 @@ module Api
         attributes :first_name, :last_name
 
         has_many :posts, namespace: "::Api::V1"
+
+        has_many :published_posts, namespace: "::Api::V1" do
+          object.posts.reject { |post| post.published_at.nil? }
+        end
       end
     end
   end

--- a/spec/system/rendering_spec.rb
+++ b/spec/system/rendering_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe "Rendering" do
           "posts" => [
             { "id" => 1, "title" => "First post" },
             { "id" => 3, "title" => "Second post!?" }
+          ],
+          "published_posts" => [
+            { "id" => 1, "title" => "First post" }
           ]
         }
       end


### PR DESCRIPTION
## Context

We need the ability to customize association calls, for example:

```ruby
class Api::V1::UserSerializer < Transmuation::Serializer
  has_many :active_subscriptions do
    object.subscriptions.active
  end
end
```

## Changes

- Add `&custom_block` parameter to the `Serializer.association` signature.
