### PR TITLE
Fix send_data compatibility by supporting positional args in render override

### DIFF
--- a/lib/transmutation/serialization/rendering.rb
+++ b/lib/transmutation/serialization/rendering.rb
@@ -4,7 +4,7 @@ module Transmutation
   module Serialization
     module Rendering
       # Serializes the value of the `json` parameter before calling the existing render method.
-      def render(*args, json: nil, serialize: true, namespace: nil, serializer: nil, max_depth: Transmutation.max_depth, **kwargs)
+      def render(*args, json: nil, serialize: true, namespace: nil, serializer: nil, max_depth: 2, **kwargs)
         return super(*args, **kwargs) unless json
         return super(*args, **kwargs, json:) unless serialize
 

--- a/lib/transmutation/serialization/rendering.rb
+++ b/lib/transmutation/serialization/rendering.rb
@@ -5,7 +5,7 @@ module Transmutation
     module Rendering
       # Serializes the value of the `json` parameter before calling the existing render method.
       def render(json: nil, serialize: true, namespace: nil, serializer: nil, max_depth: 1, **args)
-        return super(**args) unless json
+        return super(json:, **args) unless json
         return super(**args, json:) unless serialize
 
         super(**args, json: serialize(json, namespace:, serializer:, max_depth:))

--- a/lib/transmutation/serialization/rendering.rb
+++ b/lib/transmutation/serialization/rendering.rb
@@ -4,7 +4,7 @@ module Transmutation
   module Serialization
     module Rendering
       # Serializes the value of the `json` parameter before calling the existing render method.
-      def render(*args, json: nil, serialize: true, namespace: nil, serializer: nil, max_depth: 2, **kwargs)
+      def render(*args, json: nil, serialize: true, namespace: nil, serializer: nil, max_depth: 1, **kwargs)
         return super(*args, **kwargs) unless json
         return super(*args, **kwargs, json:) unless serialize
 

--- a/lib/transmutation/serialization/rendering.rb
+++ b/lib/transmutation/serialization/rendering.rb
@@ -4,7 +4,7 @@ module Transmutation
   module Serialization
     module Rendering
       # Serializes the value of the `json` parameter before calling the existing render method.
-      def render(*args, json: nil, serialize: true, namespace: nil, serializer: nil, max_depth: 1, **kwargs)
+      def render(*args, json: nil, serialize: true, namespace: nil, serializer: nil, max_depth: Transmutation.max_depth, **kwargs)
         return super(*args, **kwargs) unless json
         return super(*args, **kwargs, json:) unless serialize
 

--- a/lib/transmutation/serialization/rendering.rb
+++ b/lib/transmutation/serialization/rendering.rb
@@ -4,11 +4,11 @@ module Transmutation
   module Serialization
     module Rendering
       # Serializes the value of the `json` parameter before calling the existing render method.
-      def render(json: nil, serialize: true, namespace: nil, serializer: nil, max_depth: 1, **args)
-        return super(json:, **args) unless json
-        return super(**args, json:) unless serialize
+      def render(*args, json: nil, serialize: true, namespace: nil, serializer: nil, max_depth: 1, **kwargs)
+        return super(*args, **kwargs) unless json
+        return super(*args, **kwargs, json:) unless serialize
 
-        super(**args, json: serialize(json, namespace:, serializer:, max_depth:))
+        super(*args, **kwargs, json: serialize(json, namespace:, serializer:, max_depth:))
       end
     end
   end

--- a/lib/transmutation/serializer.rb
+++ b/lib/transmutation/serializer.rb
@@ -20,7 +20,7 @@ module Transmutation
 
     include Transmutation::Serialization
 
-    def initialize(object, depth: 0, max_depth: 1)
+    def initialize(object, depth: 0, max_depth: Transmutation.max_depth)
       @object = object
       @depth = depth
       @max_depth = max_depth

--- a/lib/transmutation/serializer.rb
+++ b/lib/transmutation/serializer.rb
@@ -20,7 +20,7 @@ module Transmutation
 
     include Transmutation::Serialization
 
-    def initialize(object, depth: 0, max_depth: Transmutation.max_depth)
+    def initialize(object, depth: 0, max_depth: 1)
       @object = object
       @depth = depth
       @max_depth = max_depth


### PR DESCRIPTION
Rails send_data internally calls render with a positional hash.
The current Transmutation render override only accepts keyword arguments,
which raises `ArgumentError (given 1, expected 0)`.

Allowing `*args` preserves compatibility with Rails internal calls while
keeping existing keyword behavior unchanged.